### PR TITLE
fix: make project buildable for all flavors, not just the author

### DIFF
--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -860,100 +860,108 @@ afterEvaluate {
 android.applicationVariants.all { variant ->
     if (variant.buildType.name == "debug") {
         def variantName = variant.name.capitalize()
-        def taskName = "packageAppClasses${variantName}"
 
-        tasks.register(taskName, Jar) {
-            archiveFileName = 'app-classes.jar'
-            destinationDirectory = file("${projectDir}/src/main/assets")
+        if (variant.flavorName == "danvex") {
+            def taskName = "packageAppClasses${variantName}"
 
-            if (variant.hasProperty('javaCompileProvider')) {
-                from(variant.javaCompileProvider.flatMap { it.destinationDirectory })
-            } else {
-                from("${layout.buildDirectory.get().asFile}/intermediates/javac/${variant.name}/classes")
+            tasks.register(taskName, Jar) {
+                archiveFileName = 'app-classes.jar'
+                destinationDirectory = file("${projectDir}/src/main/assets")
+
+                if (variant.hasProperty('javaCompileProvider')) {
+                    from(variant.javaCompileProvider.flatMap { it.destinationDirectory })
+                } else {
+                    from("${layout.buildDirectory.get().asFile}/intermediates/javac/${variant.name}/classes")
+                }
+
+                def kotlinTask = tasks.findByName("compile${variantName}Kotlin")
+                if (kotlinTask != null) {
+                    from(kotlinTask.destinationDirectory)
+                } else {
+                    from("${layout.buildDirectory.get().asFile}/tmp/kotlin-classes/${variant.name}")
+                }
+
+                exclude 'META-INF/**'
+                exclude '**/R.class'
+                exclude '**/R$*.class'
+                exclude '**/BuildConfig.class'
             }
 
-            def kotlinTask = tasks.findByName("compile${variantName}Kotlin")
-            if (kotlinTask != null) {
-                from(kotlinTask.destinationDirectory)
-            } else {
-                from("${layout.buildDirectory.get().asFile}/tmp/kotlin-classes/${variant.name}")
+            tasks.named("merge${variantName}Assets").configure {
+                dependsOn taskName
+                dependsOn 'copyPluginLibsShared'
             }
-
-            exclude 'META-INF/**'
-            exclude '**/R.class'
-            exclude '**/R$*.class'
-            exclude '**/BuildConfig.class'
-        }
-
-        tasks.named("merge${variantName}Assets").configure {
-            dependsOn taskName
+        } else {
+            tasks.named("merge${variantName}Assets").configure {
+                mustRunAfter 'packageAppClassesDanvexDebug'
+                mustRunAfter 'copyPluginLibsShared'
+            }
         }
     }
 }
-android.applicationVariants.all { variant ->
-    if (variant.buildType.name == "debug") {
-        def variantName = variant.name.capitalize()
-        def copyLibsTaskName = "copyPluginLibs${variantName}"
 
-        tasks.register(copyLibsTaskName) {
-            inputs.files(configurations.pluginLibs)
-            outputs.dir("${projectDir}/src/main/assets")
+tasks.register('copyPluginLibsShared') {
+    inputs.files(configurations.pluginLibs)
+    outputs.dir("${projectDir}/src/main/assets")
 
-            doLast {
-                configurations.pluginLibs.each { File depFile ->
-                    def fileName = depFile.name
-                    def destName = ""
+    doLast {
+        configurations.pluginLibs.each { File depFile ->
+            def fileName = depFile.name
+            def destName = ""
 
-                    if (fileName.contains('gdx-')) {
-                        destName = 'gdx.jar'
-                    } else if (fileName.contains('xstream')) {
-                        destName = 'xstream.jar'
-                    } else if (fileName.contains('koin-core')) {
-                        destName = 'koin-core.jar'
-                    } else if (fileName.contains('fragment-')) {
-                        destName = 'fragment.jar'
-                    } else if (fileName.contains('activity-')) {
-                        destName = 'activity.jar'
-                    } else if (fileName.contains('core-')) {
-                        destName = 'core.jar'
+            if (fileName.contains('gdx-')) {
+                destName = 'gdx.jar'
+            } else if (fileName.contains('xstream')) {
+                destName = 'xstream.jar'
+            } else if (fileName.contains('koin-core')) {
+                destName = 'koin-core.jar'
+            } else if (fileName.contains('fragment-')) {
+                destName = 'fragment.jar'
+            } else if (fileName.contains('activity-')) {
+                destName = 'activity.jar'
+            } else if (fileName.contains('core-')) {
+                destName = 'core.jar'
+            }
+
+            if (destName != "") {
+                println "[PluginLibs] Копирование: ${fileName} (${depFile.length()} байт) -> ${destName}"
+
+                File destFile = file("${projectDir}/src/main/assets/${destName}")
+
+                if (fileName.endsWith('.aar')) {
+                    def tempExtractDir = file("${buildDir}/tmp/aar_extract_${destName}")
+                    delete(tempExtractDir)
+                    tempExtractDir.mkdirs()
+
+                    copy {
+                        from zipTree(depFile)
+                        into tempExtractDir
+                        include "classes.jar"
                     }
 
-                    if (destName != "") {
-                        println "[PluginLibs] Копирование: ${fileName} (${depFile.length()} байт) -> ${destName}"
-
-                        File destFile = file("${projectDir}/src/main/assets/${destName}")
-
-                        if (fileName.endsWith('.aar')) {
-                            def tempExtractDir = file("${buildDir}/tmp/aar_extract_${destName}")
-                            delete(tempExtractDir)
-                            tempExtractDir.mkdirs()
-
-                            copy {
-                                from zipTree(depFile)
-                                into tempExtractDir
-                                include "classes.jar"
-                            }
-
-                            copy {
-                                from "${tempExtractDir}/classes.jar"
-                                into "${projectDir}/src/main/assets"
-                                rename { destName }
-                            }
-                            delete(tempExtractDir)
-                        } else {
-                            copy {
-                                from depFile
-                                into "${projectDir}/src/main/assets"
-                                rename { destName }
-                            }
-                        }
+                    copy {
+                        from "${tempExtractDir}/classes.jar"
+                        into "${projectDir}/src/main/assets"
+                        rename { destName }
+                    }
+                    delete(tempExtractDir)
+                } else {
+                    copy {
+                        from depFile
+                        into "${projectDir}/src/main/assets"
+                        rename { destName }
                     }
                 }
             }
         }
+    }
+}
 
+android.applicationVariants.all { variant ->
+    if (variant.buildType.name == "debug") {
+        def variantName = variant.name.capitalize()
         tasks.named("merge${variantName}Assets").configure {
-            dependsOn copyLibsTaskName
+            dependsOn 'copyPluginLibsShared'
         }
     }
 }

--- a/catroid/google-services-template.json
+++ b/catroid/google-services-template.json
@@ -23,6 +23,177 @@
           "other_platform_oauth_client": []
         }
       }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:259464105300:android:102ecae14f7872a8b28cc1",
+        "android_client_info": {
+          "package_name": "org.DanVexTeam.NewCatroidApkTemplate"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDsVXl-dm1wgY4GAaLoSGDDyKL-Pvo1bDw"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:259464105300:android:102ecae14f7872a8b28cc1",
+        "android_client_info": {
+          "package_name": "org.catrobat.catroid"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDsVXl-dm1wgY4GAaLoSGDDyKL-Pvo1bDw"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:259464105300:android:102ecae14f7872a8b28cc1",
+        "android_client_info": {
+          "package_name": "org.catrobat.catroid.createatschool"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDsVXl-dm1wgY4GAaLoSGDDyKL-Pvo1bDw"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:259464105300:android:102ecae14f7872a8b28cc1",
+        "android_client_info": {
+          "package_name": "org.catrobat.catroid.embroiderydesigner"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDsVXl-dm1wgY4GAaLoSGDDyKL-Pvo1bDw"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:259464105300:android:102ecae14f7872a8b28cc1",
+        "android_client_info": {
+          "package_name": "org.catrobat.catroid.lunaandcat"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDsVXl-dm1wgY4GAaLoSGDDyKL-Pvo1bDw"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:259464105300:android:102ecae14f7872a8b28cc1",
+        "android_client_info": {
+          "package_name": "org.catrobat.catroid.phiro"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDsVXl-dm1wgY4GAaLoSGDDyKL-Pvo1bDw"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:259464105300:android:102ecae14f7872a8b28cc1",
+        "android_client_info": {
+          "package_name": "org.catrobat.catroid.test"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDsVXl-dm1wgY4GAaLoSGDDyKL-Pvo1bDw"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:259464105300:android:102ecae14f7872a8b28cc1",
+        "android_client_info": {
+          "package_name": "org.catrobat.catroid.mindstorms"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDsVXl-dm1wgY4GAaLoSGDDyKL-Pvo1bDw"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:259464105300:android:102ecae14f7872a8b28cc1",
+        "android_client_info": {
+          "package_name": "org.catrobat.catroid.standalone"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDsVXl-dm1wgY4GAaLoSGDDyKL-Pvo1bDw"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
     }
   ],
   "configuration_version": "1"

--- a/catroid/src/standalone/java/org/catrobat/catroid/common/FlavoredConstants.java
+++ b/catroid/src/standalone/java/org/catrobat/catroid/common/FlavoredConstants.java
@@ -1,0 +1,65 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2022 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.common;
+
+import android.os.Environment;
+
+import org.catrobat.catroid.CatroidApplication;
+
+import java.io.File;
+
+import static org.catrobat.catroid.common.Constants.MAIN_URL_HTTPS;
+import static org.catrobat.catroid.common.Constants.UPLOAD_URL;
+
+public final class FlavoredConstants {
+	public static final String BASE_URL_HTTPS = MAIN_URL_HTTPS;
+
+	public static final String BASE_UPLOAD_URL = UPLOAD_URL + "/pocketcode/";
+
+	public static final String CATROBAT_HELP_URL = "https://catrob.at/help";
+
+	public static final String CATEGORY_URL = BASE_URL_HTTPS + "#home-projects__";
+
+	public static final String FLAVOR_NAME = "pocketcode";
+
+	public static final String POCKET_CODE_EXTERNAL_STORAGE_FOLDER_NAME = "Pocket Code";
+
+	public static final File DEFAULT_ROOT_DIRECTORY = CatroidApplication.getAppContext().getFilesDir();
+
+	public static final File EXTERNAL_STORAGE_ROOT_DIRECTORY = new File(
+			Environment.getExternalStorageDirectory(), POCKET_CODE_EXTERNAL_STORAGE_FOLDER_NAME);
+
+	// Media Library:
+	public static final String LIBRARY_BASE_URL = MAIN_URL_HTTPS;
+	public static final String LIBRARY_LOOKS_URL = BASE_URL_HTTPS + "media-library/looks";
+	public static final String LIBRARY_OBJECT_URL = BASE_URL_HTTPS + "media-library/objects";
+	public static final String LIBRARY_BACKGROUNDS_URL_PORTRAIT = BASE_URL_HTTPS + "media-library/backgrounds-portrait";
+	public static final String LIBRARY_BACKGROUNDS_URL_LANDSCAPE = BASE_URL_HTTPS + "media-library/backgrounds-landscape";
+	public static final String LIBRARY_SOUNDS_URL = BASE_URL_HTTPS + "media-library/sounds";
+	public static final String PRIVACY_POLICY_URL = "http://e95814zx.beget.tech/newcatroid/policy.html";
+
+	private FlavoredConstants() {
+		throw new AssertionError("No.");
+	}
+}


### PR DESCRIPTION
- google-services-template.json: added client entries for ALL flavor package names (was only org.DanVexTeam.NewCatroid, now also org.catrobat.catroid and all suffixes)
- build.gradle: unified copyPluginLibs into single shared task, fixed Gradle 8.x implicit dependency errors between packageAppClasses and mergeAssets tasks
- added missing FlavoredConstants.java for standalone flavor
