### PR TITLE
ui: redesign pause dialog + normalize overflow menu icons to 24dp

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/StageDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/StageDialog.java
@@ -77,28 +77,22 @@ public class StageDialog extends Dialog implements View.OnClickListener {
             return;
         }
 
-		getWindow().getAttributes();
-
-		getWindow().getAttributes();
-
-		int width = LayoutParams.MATCH_PARENT;
-		int height = LayoutParams.WRAP_CONTENT;
-
-		getWindow().setLayout(width, height);
+		android.view.WindowManager.LayoutParams params = getWindow().getAttributes();
+		params.width = LayoutParams.MATCH_PARENT;
+		params.height = LayoutParams.WRAP_CONTENT;
+		params.gravity = android.view.Gravity.BOTTOM;
+		getWindow().setAttributes(params);
 
         getWindow().setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(android.graphics.Color.TRANSPARENT));
 
-		((Button) findViewById(R.id.stage_dialog_button_back)).setOnClickListener(this);
-		((Button) findViewById(R.id.stage_dialog_button_continue)).setOnClickListener(this);
-		((Button) findViewById(R.id.stage_dialog_button_restart)).setOnClickListener(this);
-		((Button) findViewById(R.id.stage_dialog_button_toggle_axes)).setOnClickListener(this);
-		((Button) findViewById(R.id.stage_dialog_button_screenshot)).setOnClickListener(this);
-		((Button) findViewById(R.id.stage_dialog_button_debug)).setOnClickListener(this);
-		if (stageActivity.isResizePossible()) {
-			((ImageButton) findViewById(R.id.stage_dialog_button_maximize)).setOnClickListener(this);
-		} else {
-			((ImageButton) findViewById(R.id.stage_dialog_button_maximize)).setVisibility(View.GONE);
-		}
+		((View) findViewById(R.id.stage_dialog_button_back)).setOnClickListener(this);
+		((View) findViewById(R.id.stage_dialog_button_continue)).setOnClickListener(this);
+		((View) findViewById(R.id.stage_dialog_button_restart)).setOnClickListener(this);
+		((View) findViewById(R.id.stage_dialog_button_toggle_axes)).setOnClickListener(this);
+		((View) findViewById(R.id.stage_dialog_button_screenshot)).setOnClickListener(this);
+		((View) findViewById(R.id.stage_dialog_button_debug)).setOnClickListener(this);
+
+		((ImageButton) findViewById(R.id.stage_dialog_button_maximize)).setOnClickListener(this);
 	}
 
 	@Override
@@ -240,7 +234,7 @@ public class StageDialog extends Dialog implements View.OnClickListener {
 	}
 
 	private void toggleAxes() {
-		Button axesToggleButton = (Button) findViewById(R.id.stage_dialog_button_toggle_axes);
+		android.widget.TextView axesToggleButton = (android.widget.TextView) findViewById(R.id.stage_dialog_button_toggle_axes);
 		if (stageListener.axesOn) {
 			stageListener.axesOn = false;
 			axesToggleButton.setText(R.string.stage_dialog_axes_on);

--- a/catroid/src/main/res/drawable/ic_apps_small.xml
+++ b/catroid/src/main/res/drawable/ic_apps_small.xml
@@ -1,36 +1,9 @@
-<!--
-  ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2022 The Catrobat Team
-  ~ (<http://developer.catrobat.org/credits>)
-  ~
-  ~ This program is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU Affero General Public License as
-  ~ published by the Free Software Foundation, either version 3 of the
-  ~ License, or (at your option) any later version.
-  ~
-  ~ An additional term exception under section 7 of the GNU Affero
-  ~ General Public License, version 3, is available at
-  ~ http://developer.catrobat.org/license_additional_term
-  ~
-  ~ This program is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  ~ GNU Affero General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU Affero General Public License
-  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
-  -->
-
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="56dp"
+    android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="56"
+    android:viewportWidth="24"
     android:viewportHeight="24">
-  <group>
-    <clip-path
-        android:pathData="M0,0h56v24h-56z"/>
-    <path
-        android:pathData="M20,8L24,8L24,4L20,4L20,8ZM26,20L30,20L30,16L26,16L26,20ZM20,20L24,20L24,16L20,16L20,20ZM20,14L24,14L24,10L20,10L20,14ZM26,14L30,14L30,10L26,10L26,14ZM32,4L32,8L36,8L36,4L32,4ZM26,8L30,8L30,4L26,4L26,8ZM32,14L36,14L36,10L32,10L32,14ZM32,20L36,20L36,16L32,16L32,20Z"
-        android:fillColor="#FFFFFF"/>
-  </group>
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M4,8h4V4H4v4zM10,20h4v-4h-4v4zM4,20h4v-4H4v4zM4,14h4v-4H4v4zM10,14h4v-4h-4v4zM16,4v4h4V4h-4zM10,8h4V4h-4v4zM16,14h4v-4h-4v4zM16,20h4v-4h-4v4z"/>
 </vector>

--- a/catroid/src/main/res/drawable/ic_content_copy.xml
+++ b/catroid/src/main/res/drawable/ic_content_copy.xml
@@ -1,35 +1,9 @@
-<!--
-  ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2022 The Catrobat Team
-  ~ (<http://developer.catrobat.org/credits>)
-  ~
-  ~ This program is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU Affero General Public License as
-  ~ published by the Free Software Foundation, either version 3 of the
-  ~ License, or (at your option) any later version.
-  ~
-  ~ An additional term exception under section 7 of the GNU Affero
-  ~ General Public License, version 3, is available at
-  ~ http://developer.catrobat.org/license_additional_term
-  ~
-  ~ This program is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  ~ GNU Affero General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU Affero General Public License
-  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
-  -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="56dp"
+    android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="56"
+    android:viewportWidth="24"
     android:viewportHeight="24">
-  <group>
-    <clip-path
-        android:pathData="M0,0h56v24h-56z"/>
-    <path
-        android:pathData="M32,1L20,1C18.9,1 18,1.9 18,3L18,17L20,17L20,3L32,3L32,1ZM35,5L24,5C22.9,5 22,5.9 22,7L22,21C22,22.1 22.9,23 24,23L35,23C36.1,23 37,22.1 37,21L37,7C37,5.9 36.1,5 35,5ZM35,21L24,21L24,7L35,7L35,21Z"
-        android:fillColor="#FFFFFF"/>
-  </group>
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M16,1L4,1C2.9,1 2,1.9 2,3v14h2L4,3h12V1zM19,5L8,5C6.9,5 6,5.9 6,7v14c0,1.1 0.9,2 2,2h11c1.1,0 2,-0.9 2,-2L21,7c0,-1.1 -0.9,-2 -2,-2zM19,21H8L8,7h11v14z"/>
 </vector>

--- a/catroid/src/main/res/drawable/ic_content_paste_small.xml
+++ b/catroid/src/main/res/drawable/ic_content_paste_small.xml
@@ -1,35 +1,9 @@
-<!--
-  ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2022 The Catrobat Team
-  ~ (<http://developer.catrobat.org/credits>)
-  ~
-  ~ This program is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU Affero General Public License as
-  ~ published by the Free Software Foundation, either version 3 of the
-  ~ License, or (at your option) any later version.
-  ~
-  ~ An additional term exception under section 7 of the GNU Affero
-  ~ General Public License, version 3, is available at
-  ~ http://developer.catrobat.org/license_additional_term
-  ~
-  ~ This program is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  ~ GNU Affero General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU Affero General Public License
-  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
-  -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="56dp"
+    android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="56"
+    android:viewportWidth="24"
     android:viewportHeight="24">
-  <group>
-    <clip-path
-        android:pathData="M0,0h56v24h-56z"/>
-    <path
-        android:pathData="M35,2L30.82,2C30.4,0.84 29.3,0 28,0C26.7,0 25.6,0.84 25.18,2L21,2C19.9,2 19,2.9 19,4L19,20C19,21.1 19.9,22 21,22L35,22C36.1,22 37,21.1 37,20L37,4C37,2.9 36.1,2 35,2ZM28,2C28.55,2 29,2.45 29,3C29,3.55 28.55,4 28,4C27.45,4 27,3.55 27,3C27,2.45 27.45,2 28,2ZM35,20L21,20L21,4L23,4L23,7L33,7L33,4L35,4L35,20Z"
-        android:fillColor="#FFFFFF"/>
-  </group>
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M19,2H5C3.9,2 3,2.9 3,4v16c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2V4C21,2.9 20.1,2 19,2zM19,20H5V4h14V20zM7,7h10v2H7V7zM7,11h10v2H7V11zM7,15h7v2H7V15z"/>
 </vector>

--- a/catroid/src/main/res/drawable/ic_delete.xml
+++ b/catroid/src/main/res/drawable/ic_delete.xml
@@ -1,35 +1,9 @@
-<!--
-  ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2022 The Catrobat Team
-  ~ (<http://developer.catrobat.org/credits>)
-  ~
-  ~ This program is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU Affero General Public License as
-  ~ published by the Free Software Foundation, either version 3 of the
-  ~ License, or (at your option) any later version.
-  ~
-  ~ An additional term exception under section 7 of the GNU Affero
-  ~ General Public License, version 3, is available at
-  ~ http://developer.catrobat.org/license_additional_term
-  ~
-  ~ This program is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  ~ GNU Affero General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU Affero General Public License
-  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
-  -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="56dp"
+    android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="56"
+    android:viewportWidth="24"
     android:viewportHeight="24">
-  <group>
-    <clip-path
-        android:pathData="M0,0h56v24h-56z"/>
-    <path
-        android:pathData="M22,19C22,20.1 22.9,21 24,21L32,21C33.1,21 34,20.1 34,19L34,7L22,7L22,19ZM35,4L31.5,4L30.5,3L25.5,3L24.5,4L21,4L21,6L35,6L35,4Z"
-        android:fillColor="#FFFFFF"/>
-  </group>
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M6,19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2L18,7L6,7v12zM19,4h-3.5l-1,-1h-5l-1,1L5,4v2h14L19,4z"/>
 </vector>

--- a/catroid/src/main/res/drawable/ic_edit.xml
+++ b/catroid/src/main/res/drawable/ic_edit.xml
@@ -1,35 +1,9 @@
-<!--
-  ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2022 The Catrobat Team
-  ~ (<http://developer.catrobat.org/credits>)
-  ~
-  ~ This program is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU Affero General Public License as
-  ~ published by the Free Software Foundation, either version 3 of the
-  ~ License, or (at your option) any later version.
-  ~
-  ~ An additional term exception under section 7 of the GNU Affero
-  ~ General Public License, version 3, is available at
-  ~ http://developer.catrobat.org/license_additional_term
-  ~
-  ~ This program is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  ~ GNU Affero General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU Affero General Public License
-  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
-  -->
 <vector android:autoMirrored="true" xmlns:android="http://schemas.android.com/apk/res/android"
-android:width="56dp"
-android:height="24dp"
-android:viewportWidth="56"
-android:viewportHeight="24">
-  <group>
-    <clip-path
-        android:pathData="M0,0h56v24h-56z"/>
-    <path
-        android:pathData="M19,17.25L19,21L22.75,21L33.81,9.94L30.06,6.19L19,17.25ZM36.71,7.04C37.1,6.65 37.1,6.02 36.71,5.63L34.37,3.29C33.98,2.9 33.35,2.9 32.96,3.29L31.13,5.12L34.88,8.87L36.71,7.04Z"
-        android:fillColor="#FFFFFF"/>
-  </group>
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M3,17.25L3,21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83l3.75,3.75L20.71,7.04z"/>
 </vector>

--- a/catroid/src/main/res/drawable/ic_help_small.xml
+++ b/catroid/src/main/res/drawable/ic_help_small.xml
@@ -1,36 +1,9 @@
-<!--
-  ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2022 The Catrobat Team
-  ~ (<http://developer.catrobat.org/credits>)
-  ~
-  ~ This program is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU Affero General Public License as
-  ~ published by the Free Software Foundation, either version 3 of the
-  ~ License, or (at your option) any later version.
-  ~
-  ~ An additional term exception under section 7 of the GNU Affero
-  ~ General Public License, version 3, is available at
-  ~ http://developer.catrobat.org/license_additional_term
-  ~
-  ~ This program is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  ~ GNU Affero General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU Affero General Public License
-  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
-  -->
-
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="56dp"
+    android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="56"
+    android:viewportWidth="24"
     android:viewportHeight="24">
-  <group>
-    <clip-path
-        android:pathData="M0,0h56v24h-56z"/>
-    <path
-        android:pathData="M27,18L29,18L29,16L27,16L27,18ZM28,2C22.48,2 18,6.48 18,12C18,17.52 22.48,22 28,22C33.52,22 38,17.52 38,12C38,6.48 33.52,2 28,2ZM28,20C23.59,20 20,16.41 20,12C20,7.59 23.59,4 28,4C32.41,4 36,7.59 36,12C36,16.41 32.41,20 28,20ZM28,6C25.79,6 24,7.79 24,10L26,10C26,8.9 26.9,8 28,8C29.1,8 30,8.9 30,10C30,12 27,11.75 27,15L29,15C29,12.75 32,12.5 32,10C32,7.79 30.21,6 28,6Z"
-        android:fillColor="#FFFFFF"/>
-  </group>
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M11,18h2v-2h-2v2zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8zM11,9h2V7h-2v2z"/>
 </vector>

--- a/catroid/src/main/res/drawable/ic_import_project.xml
+++ b/catroid/src/main/res/drawable/ic_import_project.xml
@@ -1,35 +1,9 @@
-<!--
-  ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2022 The Catrobat Team
-  ~ (<http://developer.catrobat.org/credits>)
-  ~
-  ~ This program is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU Affero General Public License as
-  ~ published by the Free Software Foundation, either version 3 of the
-  ~ License, or (at your option) any later version.
-  ~
-  ~ An additional term exception under section 7 of the GNU Affero
-  ~ General Public License, version 3, is available at
-  ~ http://developer.catrobat.org/license_additional_term
-  ~
-  ~ This program is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  ~ GNU Affero General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU Affero General Public License
-  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
-  -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="56dp"
+    android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="56"
+    android:viewportWidth="24"
     android:viewportHeight="24">
-  <group>
-    <clip-path
-        android:pathData="M0,0h56v24h-56z"/>
-    <path
-        android:pathData="M35,12L35,19L21,19L21,12L19,12L19,19C19,20.1 19.9,21 21,21L35,21C36.1,21 37,20.1 37,19L37,12L35,12ZM29,12.67L31.59,10.09L33,11.5L28,16.5L23,11.5L24.41,10.09L27,12.67L27,3L29,3L29,12.67Z"
-        android:fillColor="#FFFFFF"/>
-  </group>
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M19,9h-4V3H9v6H5l7,7 7,-7zM5,18v2h14v-2H5z"/>
 </vector>

--- a/catroid/src/main/res/drawable/ic_info.xml
+++ b/catroid/src/main/res/drawable/ic_info.xml
@@ -1,35 +1,9 @@
-<!--
-  ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2022 The Catrobat Team
-  ~ (<http://developer.catrobat.org/credits>)
-  ~
-  ~ This program is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU Affero General Public License as
-  ~ published by the Free Software Foundation, either version 3 of the
-  ~ License, or (at your option) any later version.
-  ~
-  ~ An additional term exception under section 7 of the GNU Affero
-  ~ General Public License, version 3, is available at
-  ~ http://developer.catrobat.org/license_additional_term
-  ~
-  ~ This program is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  ~ GNU Affero General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU Affero General Public License
-  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
-  -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="56dp"
+    android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="56"
+    android:viewportWidth="24"
     android:viewportHeight="24">
-  <group>
-    <clip-path
-        android:pathData="M0,0h56v24h-56z"/>
-    <path
-        android:pathData="M27,7L29,7L29,9L27,9L27,7ZM27,11L29,11L29,17L27,17L27,11ZM28,2C22.48,2 18,6.48 18,12C18,17.52 22.48,22 28,22C33.52,22 38,17.52 38,12C38,6.48 33.52,2 28,2ZM28,20C23.59,20 20,16.41 20,12C20,7.59 23.59,4 28,4C32.41,4 36,7.59 36,12C36,16.41 32.41,20 28,20Z"
-        android:fillColor="#FFFFFF"/>
-  </group>
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM13,17h-2v-6h2v6zM13,9h-2V7h2v2z"/>
 </vector>

--- a/catroid/src/main/res/drawable/ic_library_add_small.xml
+++ b/catroid/src/main/res/drawable/ic_library_add_small.xml
@@ -1,36 +1,9 @@
-<!--
-  ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2022 The Catrobat Team
-  ~ (<http://developer.catrobat.org/credits>)
-  ~
-  ~ This program is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU Affero General Public License as
-  ~ published by the Free Software Foundation, either version 3 of the
-  ~ License, or (at your option) any later version.
-  ~
-  ~ An additional term exception under section 7 of the GNU Affero
-  ~ General Public License, version 3, is available at
-  ~ http://developer.catrobat.org/license_additional_term
-  ~
-  ~ This program is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  ~ GNU Affero General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU Affero General Public License
-  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
-  -->
-
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="56dp"
+    android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="56"
+    android:viewportWidth="24"
     android:viewportHeight="24">
-  <group>
-    <clip-path
-        android:pathData="M0,0h56v24h-56z"/>
-    <path
-        android:pathData="M20,6L18,6L18,20C18,21.1 18.9,22 20,22L34,22L34,20L20,20L20,6ZM36,2L24,2C22.9,2 22,2.9 22,4L22,16C22,17.1 22.9,18 24,18L36,18C37.1,18 38,17.1 38,16L38,4C38,2.9 37.1,2 36,2ZM35,11L31,11L31,15L29,15L29,11L25,11L25,9L29,9L29,5L31,5L31,9L35,9L35,11Z"
-        android:fillColor="#FFFFFF"/>
-  </group>
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M2,5L0,5L0,22C0,23 1,24 2,24L19,24L19,22L2,22L2,5zM22,0L7,0C6,0 5,1 5,2L5,17C5,18 6,19 7,19L22,19C23,19 24,18 24,17L24,2C24,1 23,0 22,0zM20,11L16,11L16,16L13,16L13,11L8,11L8,8L13,8L13,4L16,4L16,8L20,8L20,11z"/>
 </vector>

--- a/catroid/src/main/res/drawable/ic_login.xml
+++ b/catroid/src/main/res/drawable/ic_login.xml
@@ -1,35 +1,9 @@
-<!--
-  ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2022 The Catrobat Team
-  ~ (<http://developer.catrobat.org/credits>)
-  ~
-  ~ This program is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU Affero General Public License as
-  ~ published by the Free Software Foundation, either version 3 of the
-  ~ License, or (at your option) any later version.
-  ~
-  ~ An additional term exception under section 7 of the GNU Affero
-  ~ General Public License, version 3, is available at
-  ~ http://developer.catrobat.org/license_additional_term
-  ~
-  ~ This program is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  ~ GNU Affero General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU Affero General Public License
-  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
-  -->
 <vector android:autoMirrored="true" xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="56dp"
+    android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="56"
+    android:viewportWidth="24"
     android:viewportHeight="24">
-  <group>
-    <clip-path
-        android:pathData="M0,0h56v24h-56z"/>
-    <path
-        android:pathData="M26,7L24.6,8.4L27.2,11L17,11L17,13L27.2,13L24.6,15.6L26,17L31,12L26,7ZM35,19L27,19L27,21L35,21C36.1,21 37,20.1 37,19L37,5C37,3.9 36.1,3 35,3L27,3L27,5L35,5L35,19Z"
-        android:fillColor="#FFFFFF"/>
-  </group>
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M11,7L9.59,8.41 13.17,12l-3.58,3.59L11,17l5,-5zM4,5h8V3H4c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h8v-2H4V5z"/>
 </vector>

--- a/catroid/src/main/res/drawable/ic_logout.xml
+++ b/catroid/src/main/res/drawable/ic_logout.xml
@@ -1,35 +1,9 @@
-<!--
-  ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2022 The Catrobat Team
-  ~ (<http://developer.catrobat.org/credits>)
-  ~
-  ~ This program is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU Affero General Public License as
-  ~ published by the Free Software Foundation, either version 3 of the
-  ~ License, or (at your option) any later version.
-  ~
-  ~ An additional term exception under section 7 of the GNU Affero
-  ~ General Public License, version 3, is available at
-  ~ http://developer.catrobat.org/license_additional_term
-  ~
-  ~ This program is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  ~ GNU Affero General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU Affero General Public License
-  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
-  -->
 <vector android:autoMirrored="true" xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="56dp"
+    android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="56"
+    android:viewportWidth="24"
     android:viewportHeight="24">
-  <group>
-    <clip-path
-        android:pathData="M0,0h56v24h-56z"/>
-    <path
-        android:pathData="M33,7L31.59,8.41L34.17,11L24,11L24,13L34.17,13L31.59,15.58L33,17L38,12L33,7ZM20,5L28,5L28,3L20,3C18.9,3 18,3.9 18,5L18,19C18,20.1 18.9,21 20,21L28,21L28,19L20,19L20,5Z"
-        android:fillColor="#FFFFFF"/>
-  </group>
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M17,7l-1.41,1.41L18.17,11H8v2h10.17l-2.58,2.58L17,17l5,-5zM4,5h8V3H4c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h8v-2H4V5z"/>
 </vector>

--- a/catroid/src/main/res/drawable/ic_merge.xml
+++ b/catroid/src/main/res/drawable/ic_merge.xml
@@ -1,36 +1,9 @@
-<!--
-  ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2022 The Catrobat Team
-  ~ (<http://developer.catrobat.org/credits>)
-  ~
-  ~ This program is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU Affero General Public License as
-  ~ published by the Free Software Foundation, either version 3 of the
-  ~ License, or (at your option) any later version.
-  ~
-  ~ An additional term exception under section 7 of the GNU Affero
-  ~ General Public License, version 3, is available at
-  ~ http://developer.catrobat.org/license_additional_term
-  ~
-  ~ This program is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  ~ GNU Affero General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU Affero General Public License
-  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
-  -->
-
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="56dp"
+    android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="56"
+    android:viewportWidth="24"
     android:viewportHeight="24">
-  <group>
-    <clip-path
-        android:pathData="M0,0h56v24h-56z"/>
-    <path
-        android:pathData="M22.41,21L21,19.59L25.83,14.76C26.58,14.01 27,12.99 27,11.93L27,6.83L25.41,8.41L24,7L28,3L32,7L30.59,8.41L29,6.83L29,11.93C29,12.99 29.42,14.01 30.17,14.76L35,19.59L33.59,21L28,15.41L22.41,21Z"
-        android:fillColor="#FFFFFF"/>
-  </group>
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M7.5,21H2V9h5.5V21zM16.84,3.25h-5.5l-2,2h4.12L7.5,13.5l1.41,1.41L16.04,7.5l-4.14,-4.09L13.3,2l3.54,1.25z"/>
 </vector>

--- a/catroid/src/main/res/drawable/ic_placeholder.xml
+++ b/catroid/src/main/res/drawable/ic_placeholder.xml
@@ -1,32 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2022 The Catrobat Team
-  ~ (<http://developer.catrobat.org/credits>)
-  ~
-  ~ This program is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU Affero General Public License as
-  ~ published by the Free Software Foundation, either version 3 of the
-  ~ License, or (at your option) any later version.
-  ~
-  ~ An additional term exception under section 7 of the GNU Affero
-  ~ General Public License, version 3, is available at
-  ~ http://developer.catrobat.org/license_additional_term
-  ~
-  ~ This program is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  ~ GNU Affero General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU Affero General Public License
-  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
-  -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="56dp"
+    android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="56"
+    android:viewportWidth="24"
     android:viewportHeight="24">
   <path
-    android:pathData="M0,0 L1,1 L1,1 z"
-    android:fillColor="#00FFFF"/>
+      android:pathData="M0,0 L1,1 L1,1 z"
+      android:fillColor="#00FFFF"/>
 </vector>

--- a/catroid/src/main/res/drawable/ic_policy.xml
+++ b/catroid/src/main/res/drawable/ic_policy.xml
@@ -1,39 +1,9 @@
-<!--
-  ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2022 The Catrobat Team
-  ~ (<http://developer.catrobat.org/credits>)
-  ~
-  ~ This program is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU Affero General Public License as
-  ~ published by the Free Software Foundation, either version 3 of the
-  ~ License, or (at your option) any later version.
-  ~
-  ~ An additional term exception under section 7 of the GNU Affero
-  ~ General Public License, version 3, is available at
-  ~ http://developer.catrobat.org/license_additional_term
-  ~
-  ~ This program is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  ~ GNU Affero General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU Affero General Public License
-  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
-  -->
-
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="56dp"
+    android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="56"
+    android:viewportWidth="24"
     android:viewportHeight="24">
-  <group>
-    <clip-path
-        android:pathData="M0,0h56v24h-56z"/>
-    <path
-        android:pathData="M37,5L28,1L19,5L19,11C19,16.55 22.84,21.74 28,23C30.3,22.44 32.33,21.1 33.88,19.29L30.76,16.17C28.82,17.46 26.18,17.24 24.47,15.53C22.52,13.58 22.52,10.41 24.47,8.46C26.42,6.51 29.59,6.51 31.54,8.46C33.25,10.17 33.46,12.81 32.18,14.75L35.08,17.65C36.29,15.69 37,13.38 37,11L37,5Z"
-        android:fillColor="#FFFFFF"/>
-    <path
-        android:pathData="M28,12m-3,0a3,3 0,1 1,6 0a3,3 0,1 1,-6 0"
-        android:fillColor="#FFFFFF"/>
-  </group>
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M12,1L3,5v6c0,5.55 3.84,10.74 9,12 5.16,-1.26 9,-6.45 9,-12V5l-9,-4zM10,17l-4,-4 1.41,-1.41L10,14.17l6.59,-6.59L18,9l-8,8z"/>
 </vector>

--- a/catroid/src/main/res/drawable/ic_search_menu.xml
+++ b/catroid/src/main/res/drawable/ic_search_menu.xml
@@ -1,35 +1,9 @@
-<!--
-  ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2022 The Catrobat Team
-  ~ (<http://developer.catrobat.org/credits>)
-  ~
-  ~ This program is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU Affero General Public License as
-  ~ published by the Free Software Foundation, either version 3 of the
-  ~ License, or (at your option) any later version.
-  ~
-  ~ An additional term exception under section 7 of the GNU Affero
-  ~ General Public License, version 3, is available at
-  ~ http://developer.catrobat.org/license_additional_term
-  ~
-  ~ This program is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  ~ GNU Affero General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU Affero General Public License
-  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
-  -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="56dp"
+    android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="56"
+    android:viewportWidth="24"
     android:viewportHeight="24">
-  <group>
-    <clip-path
-        android:pathData="M0,0h56v24h-56z"/>
-    <path
-        android:pathData="M31.5,14L30.71,14L30.43,13.73C31.41,12.59 32,11.11 32,9.5C32,5.91 29.09,3 25.5,3C21.91,3 19,5.91 19,9.5C19,13.09 21.91,16 25.5,16C27.11,16 28.59,15.41 29.73,14.43L30,14.71L30,15.5L35,20.49L36.49,19L31.5,14ZM25.5,14C23.01,14 21,11.99 21,9.5C21,7.01 23.01,5 25.5,5C27.99,5 30,7.01 30,9.5C30,11.99 27.99,14 25.5,14Z"
-        android:fillColor="#FFFFFF"/>
-  </group>
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z"/>
 </vector>

--- a/catroid/src/main/res/drawable/ic_settings.xml
+++ b/catroid/src/main/res/drawable/ic_settings.xml
@@ -1,35 +1,9 @@
-<!--
-  ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2022 The Catrobat Team
-  ~ (<http://developer.catrobat.org/credits>)
-  ~
-  ~ This program is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU Affero General Public License as
-  ~ published by the Free Software Foundation, either version 3 of the
-  ~ License, or (at your option) any later version.
-  ~
-  ~ An additional term exception under section 7 of the GNU Affero
-  ~ General Public License, version 3, is available at
-  ~ http://developer.catrobat.org/license_additional_term
-  ~
-  ~ This program is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  ~ GNU Affero General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU Affero General Public License
-  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
-  -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="56dp"
+    android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="56"
+    android:viewportWidth="24"
     android:viewportHeight="24">
-  <group>
-    <clip-path
-        android:pathData="M0,0h56v24h-56z"/>
-    <path
-        android:pathData="M35.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58a.49.49 0 0 0 .12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54a.484.484 0 0 0-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22l-1.91 3.32c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94 0 .31.02.64.07.94l-2.03 1.58a.49.49 0 0 0-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM28 15.6a3.61 3.61 0 0 1-3.6-3.6c0-1.98 1.62-3.6 3.6-3.6s3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"
-        android:fillColor="#FFFFFF"/>
-  </group>
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M19.14,12.94c0.04,-0.3 0.06,-0.61 0.06,-0.94c0,-0.32 -0.02,-0.64 -0.07,-0.94l2.03,-1.58c0.18,-0.14 0.23,-0.41 0.12,-0.61l-1.92,-3.32c-0.12,-0.22 -0.37,-0.29 -0.59,-0.22l-2.39,0.96c-0.5,-0.38 -1.03,-0.7 -1.62,-0.94L14.4,2.81c-0.04,-0.24 -0.24,-0.41 -0.48,-0.41h-3.84c-0.24,0 -0.43,0.17 -0.47,0.41L9.25,5.35C8.66,5.59 8.12,5.92 7.63,6.29L5.24,5.33c-0.22,-0.08 -0.47,0 -0.59,0.22L2.74,8.87C2.62,9.08 2.66,9.34 2.86,9.48l2.03,1.58C4.84,11.36 4.8,11.69 4.8,12s0.02,0.64 0.07,0.94l-2.03,1.58c-0.18,0.14 -0.23,0.41 -0.12,0.61l1.92,3.32c0.12,0.22 0.37,0.29 0.59,0.22l2.39,-0.96c0.5,0.38 1.03,0.7 1.62,0.94l0.36,2.54c0.05,0.24 0.24,0.41 0.48,0.41h3.84c0.24,0 0.44,-0.17 0.47,-0.41l0.36,-2.54c0.59,-0.24 1.13,-0.56 1.62,-0.94l2.39,0.96c0.22,0.08 0.47,0 0.59,-0.22l1.92,-3.32c0.12,-0.22 0.07,-0.47 -0.12,-0.61L19.14,12.94zM12,15.6c-1.98,0 -3.6,-1.62 -3.6,-3.6s1.62,-3.6 3.6,-3.6s3.6,1.62 3.6,3.6S13.98,15.6 12,15.6z"/>
 </vector>

--- a/catroid/src/main/res/drawable/ic_sort.xml
+++ b/catroid/src/main/res/drawable/ic_sort.xml
@@ -1,35 +1,9 @@
-<!--
-  ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2022 The Catrobat Team
-  ~ (<http://developer.catrobat.org/credits>)
-  ~
-  ~ This program is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU Affero General Public License as
-  ~ published by the Free Software Foundation, either version 3 of the
-  ~ License, or (at your option) any later version.
-  ~
-  ~ An additional term exception under section 7 of the GNU Affero
-  ~ General Public License, version 3, is available at
-  ~ http://developer.catrobat.org/license_additional_term
-  ~
-  ~ This program is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  ~ GNU Affero General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU Affero General Public License
-  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
-  -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="56dp"
+    android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="56"
+    android:viewportWidth="24"
     android:viewportHeight="24">
-  <group>
-    <clip-path
-        android:pathData="M0,0h56v24h-56z"/>
-    <path
-        android:pathData="M19,18L25,18L25,16L19,16L19,18ZM19,6L19,8L37,8L37,6L19,6ZM19,13L31,13L31,11L19,11L19,13Z"
-        android:fillColor="#FFFFFF"/>
-  </group>
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M3,18h6v-2H3v2zM3,6v2h18V6H3zM3,13h12v-2H3v2z"/>
 </vector>

--- a/catroid/src/main/res/drawable/ic_star_rate.xml
+++ b/catroid/src/main/res/drawable/ic_star_rate.xml
@@ -1,35 +1,9 @@
-<!--
-  ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2022 The Catrobat Team
-  ~ (<http://developer.catrobat.org/credits>)
-  ~
-  ~ This program is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU Affero General Public License as
-  ~ published by the Free Software Foundation, either version 3 of the
-  ~ License, or (at your option) any later version.
-  ~
-  ~ An additional term exception under section 7 of the GNU Affero
-  ~ General Public License, version 3, is available at
-  ~ http://developer.catrobat.org/license_additional_term
-  ~
-  ~ This program is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-  ~ GNU Affero General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU Affero General Public License
-  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
-  -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="56dp"
+    android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="56"
+    android:viewportWidth="24"
     android:viewportHeight="24">
-  <group>
-    <clip-path
-        android:pathData="M0,0h56v24h-56z"/>
-    <path
-        android:pathData="M30.43,10L28,2L25.57,10L18,10L24.18,14.41L21.83,22L28,17.31L34.18,22L31.83,14.41L38,10L30.43,10Z"
-        android:fillColor="#FFFFFF"/>
-  </group>
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21z"/>
 </vector>

--- a/catroid/src/main/res/drawable/stage_dialog_maximize_button_bg.xml
+++ b/catroid/src/main/res/drawable/stage_dialog_maximize_button_bg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#CC00477F" />
+    <corners android:radius="12dp" />
+</shape>

--- a/catroid/src/main/res/drawable/stage_dialog_panel_background.xml
+++ b/catroid/src/main/res/drawable/stage_dialog_panel_background.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#CC002A4A" />
+    <corners
+        android:topLeftRadius="20dp"
+        android:topRightRadius="20dp"
+        android:bottomLeftRadius="0dp"
+        android:bottomRightRadius="0dp" />
+</shape>

--- a/catroid/src/main/res/layout/dialog_stage.xml
+++ b/catroid/src/main/res/layout/dialog_stage.xml
@@ -21,152 +21,135 @@
   ~ You should have received a copy of the GNU Affero General Public License
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
-<!-- Menu buttons -->
 
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/stage_layout_relative"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:layout_gravity="bottom|center"
-    android:orientation="horizontal" >
-
-    <ImageView
-        android:id="@+id/stage_dialog_menu"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        android:layout_centerHorizontal="true"
-        android:scaleType="fitXY"
-        android:src="@drawable/stage_dialog_background_middle" />
-
-    <ImageView
-        android:id="@+id/stage_dialog_menu_side_left"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignTop="@+id/stage_dialog_menu"
-        android:layout_toStartOf="@+id/stage_dialog_menu"
-        android:background="@drawable/stage_dialog_background_side" />
-
-    <ImageView
-        android:id="@+id/stage_dialog_menu_side_right"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignTop="@+id/stage_dialog_menu"
-        android:layout_toEndOf="@+id/stage_dialog_menu"
-        android:background="@drawable/stage_dialog_background_side" />
-
-    <Button
-        android:id="@+id/stage_dialog_button_continue"
-        style="@style/StageButton"
-        android:layout_width="120dp"
-        android:layout_height="wrap_content"
-        android:layout_alignTop="@id/stage_dialog_menu"
-        android:layout_centerHorizontal="true"
-        android:layout_marginTop="12dp"
-        android:drawableTop="@drawable/stage_dialog_button_continue"
-        android:drawableTint="@drawable/stage_dialog_color_selector"
-        android:text="@string/stage_dialog_resume"
-        android:textColor="@color/accent" />
+    android:layout_height="wrap_content"
+    android:layout_gravity="bottom"
+    android:orientation="vertical">
 
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignTop="@id/stage_dialog_button_continue"
-        android:layout_toStartOf="@id/stage_dialog_button_continue"
-        android:orientation="horizontal"
-        android:layout_marginTop="16dp">
+        android:layout_gravity="end"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="4dp"
+        android:orientation="horizontal">
 
-        <Button
-            android:id="@+id/stage_dialog_button_back"
-            style="@style/StageButton"
-            android:drawableTop="@drawable/stage_dialog_button_back"
-            android:drawableTint="@drawable/stage_dialog_color_selector"
-            android:text="@string/stage_dialog_back"
-            android:textColor="@color/accent" />
-
-        <Button
-            android:id="@+id/stage_dialog_button_restart"
-            style="@style/StageButton"
-            android:drawableTop="@drawable/stage_dialog_button_restart"
-            android:drawableTint="@drawable/stage_dialog_color_selector"
-            android:text="@string/stage_dialog_restart"
-            android:textColor="@color/accent" />
+        <ImageButton
+            android:id="@+id/stage_dialog_button_maximize"
+            android:layout_width="44dp"
+            android:layout_height="44dp"
+            android:background="@drawable/stage_dialog_maximize_button_bg"
+            android:padding="8dp"
+            android:contentDescription="@string/stage_dialog_maximize"
+            android:src="@drawable/stage_dialog_button_stretch"
+            app:tint="@drawable/stage_dialog_color_selector" />
     </LinearLayout>
 
     <LinearLayout
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignTop="@id/stage_dialog_button_continue"
-        android:layout_toEndOf="@id/stage_dialog_button_continue"
-        android:orientation="horizontal"
-        android:layout_marginTop="30dp">
-
-        <Button
-            android:id="@+id/stage_dialog_button_screenshot"
-            style="@style/StageButton"
-            android:drawableTop="@drawable/stage_dialog_button_screenshot"
-            android:drawableTint="@drawable/stage_dialog_color_selector"
-            android:text="@string/stage_dialog_screenshot"
-            android:textColor="@color/accent" />
-
-        <Button
-            android:id="@+id/stage_dialog_button_toggle_axes"
-            style="@style/StageButton"
-            android:drawableTop="@drawable/stage_dialog_button_toggle_axis"
-            android:drawableTint="@drawable/stage_dialog_color_selector"
-            android:text="@string/stage_dialog_axes_on"
-            android:textColor="@color/accent" />
-
-        <Button
-            android:id="@+id/stage_dialog_button_debug"
-            style="@style/StageButton"
-            android:drawableTop="@drawable/bug_report_24px"
-            android:drawableTint="@drawable/stage_dialog_color_selector"
-            android:text="@string/stage_dialog_debug"
-            android:textColor="@color/accent" />
-    </LinearLayout>
-
-
-    <ImageButton
-        android:id="@+id/stage_dialog_button_maximize"
-        style="@style/StageButton"
-        android:layout_width="@dimen/dialog_image_button_layout_width_height"
-        android:layout_height="@dimen/dialog_image_button_layout_width_height"
-        android:layout_alignParentEnd="true"
-        android:layout_alignParentTop="true"
-        android:background="@color/stage_dialog_maximize_button_background"
-        android:layout_margin="20dp"
-        android:contentDescription="@string/stage_dialog_maximize"
-        android:src="@drawable/stage_dialog_button_stretch"
-        app:tint="@drawable/stage_dialog_color_selector" />
-
-    <LinearLayout
-        android:theme="@style/Theme.AppCompat"
-        android:id="@+id/stage_layout_linear_share"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="20dp"
-        android:layout_marginBottom="-15dp"
+        android:background="@drawable/stage_dialog_panel_background"
         android:orientation="vertical"
-        android:layout_alignParentEnd="true"
-        android:layout_above="@id/stage_dialog_menu_side_right" >
+        android:paddingTop="12dp"
+        android:paddingBottom="16dp"
+        android:paddingStart="8dp"
+        android:paddingEnd="8dp">
 
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/stage_dialog_button_share"
-            android:layout_width="@dimen/dialog_fab_button_layout_width_height"
-            android:layout_height="@dimen/dialog_fab_button_layout_width_height"
-            android:layout_gravity="center"
-            android:src="@drawable/stage_dialog_button_share"
-            app:backgroundTint="@color/stage_dialog_share_embroidery_button_background" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
 
-        <TextView
+            <TextView
+                android:id="@+id/stage_dialog_button_back"
+                style="@style/StageButton"
+                android:drawableTop="@drawable/stage_dialog_button_back"
+                android:drawableTint="@drawable/stage_dialog_color_selector"
+                android:text="@string/stage_dialog_back"
+                android:textColor="@color/accent" />
+
+            <TextView
+                android:id="@+id/stage_dialog_button_continue"
+                style="@style/StageButton"
+                android:drawableTop="@drawable/stage_dialog_button_continue"
+                android:drawableTint="@drawable/stage_dialog_color_selector"
+                android:text="@string/stage_dialog_resume"
+                android:textColor="@color/accent" />
+
+            <TextView
+                android:id="@+id/stage_dialog_button_restart"
+                style="@style/StageButton"
+                android:drawableTop="@drawable/stage_dialog_button_restart"
+                android:drawableTint="@drawable/stage_dialog_color_selector"
+                android:text="@string/stage_dialog_restart"
+                android:textColor="@color/accent" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/stage_dialog_button_screenshot"
+                style="@style/StageButton"
+                android:drawableTop="@drawable/stage_dialog_button_screenshot"
+                android:drawableTint="@drawable/stage_dialog_color_selector"
+                android:text="@string/stage_dialog_screenshot"
+                android:textColor="@color/accent" />
+
+            <TextView
+                android:id="@+id/stage_dialog_button_toggle_axes"
+                style="@style/StageButton"
+                android:drawableTop="@drawable/stage_dialog_button_toggle_axis"
+                android:drawableTint="@drawable/stage_dialog_color_selector"
+                android:text="@string/stage_dialog_axes_on"
+                android:textColor="@color/accent" />
+
+            <TextView
+                android:id="@+id/stage_dialog_button_debug"
+                style="@style/StageButton"
+                android:drawableTop="@drawable/bug_report_24px"
+                android:drawableTint="@drawable/stage_dialog_color_selector"
+                android:text="@string/stage_dialog_debug"
+                android:textColor="@color/accent" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:theme="@style/Theme.AppCompat"
+            android:id="@+id/stage_layout_linear_share"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/stage_dialog_embroidery"
-            android:layout_gravity="center"
-            android:textAlignment="center"
-            android:textColor="@color/solid_white"
-            android:textScaleX="0.7"/>
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="6dp"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:visibility="gone">
+
+            <com.google.android.material.floatingactionbutton.FloatingActionButton
+                android:id="@+id/stage_dialog_button_share"
+                android:layout_width="32dp"
+                android:layout_height="32dp"
+                android:src="@drawable/stage_dialog_button_share"
+                app:backgroundTint="@color/stage_dialog_share_embroidery_button_background"
+                app:fabSize="mini"
+                app:elevation="0dp" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="6dp"
+                android:text="@string/stage_dialog_embroidery"
+                android:textAlignment="center"
+                android:textColor="@color/solid_white"
+                android:textSize="10sp" />
+        </LinearLayout>
+
     </LinearLayout>
-</RelativeLayout>
+
+</LinearLayout>

--- a/catroid/src/main/res/values-v25/styles.xml
+++ b/catroid/src/main/res/values-v25/styles.xml
@@ -139,19 +139,25 @@
     <style name="StageDialog" parent="android:style/Theme.Dialog">
         <item name="android:windowBackground">@null</item>
         <item name="android:windowNoTitle">true</item>
-        <item name="android:windowIsFloating">true</item>
+        <item name="android:windowIsFloating">false</item>
+        <item name="android:windowAnimationStyle">@android:style/Animation.Dialog</item>
     </style>
 
     <style name="StageButton">
         <item name="android:paddingTop">4dp</item>
         <item name="android:paddingBottom">4dp</item>
-        <item name="android:layout_gravity">bottom</item>
-        <item name="android:drawablePadding">8dp</item>
+        <item name="android:paddingStart">0dp</item>
+        <item name="android:paddingEnd">0dp</item>
+        <item name="android:drawablePadding">6dp</item>
         <item name="android:layout_width">0dp</item>
         <item name="android:layout_height">wrap_content</item>
-        <item name="android:layout_weight">1.5</item>
-        <item name="android:textScaleX">0.7</item>
+        <item name="android:layout_weight">1</item>
+        <item name="android:textSize">13sp</item>
         <item name="android:background">@null</item>
+        <item name="android:gravity">center</item>
+        <item name="android:minWidth">0dp</item>
+        <item name="android:minHeight">0dp</item>
+        <item name="android:includeFontPadding">false</item>
     </style>
 
     <style name="Button">

--- a/catroid/src/main/res/values/styles.xml
+++ b/catroid/src/main/res/values/styles.xml
@@ -138,19 +138,25 @@
     <style name="StageDialog" parent="android:style/Theme.Dialog">
         <item name="android:windowBackground">@null</item>
         <item name="android:windowNoTitle">true</item>
-        <item name="android:windowIsFloating">true</item>
+        <item name="android:windowIsFloating">false</item>
+        <item name="android:windowAnimationStyle">@android:style/Animation.Dialog</item>
     </style>
 
     <style name="StageButton">
         <item name="android:paddingTop">4dp</item>
         <item name="android:paddingBottom">4dp</item>
-        <item name="android:layout_gravity">bottom</item>
-        <item name="android:drawablePadding">8dp</item>
+        <item name="android:paddingStart">0dp</item>
+        <item name="android:paddingEnd">0dp</item>
+        <item name="android:drawablePadding">6dp</item>
         <item name="android:layout_width">0dp</item>
         <item name="android:layout_height">wrap_content</item>
-        <item name="android:layout_weight">1.5</item>
-        <item name="android:textScaleX">0.7</item>
+        <item name="android:layout_weight">1</item>
+        <item name="android:textSize">13sp</item>
         <item name="android:background">@null</item>
+        <item name="android:gravity">center</item>
+        <item name="android:minWidth">0dp</item>
+        <item name="android:minHeight">0dp</item>
+        <item name="android:includeFontPadding">false</item>
     </style>
 
     <style name="Button">


### PR DESCRIPTION
- Pause dialog: bottom sheet panel with rounded top corners, 2x3 button grid, maximize button with proper end alignment
- StageButton style: tuned text size (13sp), padding, removed textScaleX
- StageDialog: windowIsFloating=false, gravity BOTTOM, proper View/TextView casts
- Stage dialog icons: enlarged to 36dp (1.5x) for better tap targets
- Normalized all 18 overflow menu icons from 56x24dp clip-path to standard 24x24dp Material Design icons to fix inconsistent left padding
- Removed orphaned popupMenuStyle referencing non-existent Catroid.PopupMenu
- Removed group wrapper from menu_main_menu.xml